### PR TITLE
common: cursor.Parse("123A") should not fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 go:
     - tip
-    - 1.3
-    - 1.2
+    - 1.5
+    - 1.4
 
 services:
     - redis-server

--- a/common/cursor.go
+++ b/common/cursor.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"strconv"
+	"strings"
 )
 
 // Cursor is used as part of SelectRange.
@@ -50,19 +52,19 @@ func (c Cursor) Encode(w io.Writer) {
 
 // Parse parses the cursor string into the Cursor object.
 func (c *Cursor) Parse(s string) error {
-	var (
-		score  uint64
-		member string
-	)
-
-	_, err := fmt.Fscanf(bytes.NewReader([]byte(s)), cursorFormat, &score, &member)
-	if err != nil {
-		return fmt.Errorf("invalid cursor string (%s)", err)
+	fields := strings.SplitN(s, "A", 2)
+	if len(fields) != 2 {
+		return fmt.Errorf("invalid cursor string (%s)", s)
 	}
 
-	decoded, err := ioutil.ReadAll(base64.NewDecoder(base64.URLEncoding, bytes.NewReader([]byte(member))))
+	score, err := strconv.ParseUint(fields[0], 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid cursor string (%s)", err)
+		return fmt.Errorf("invalid score in cursor string (%s)", err)
+	}
+
+	decoded, err := ioutil.ReadAll(base64.NewDecoder(base64.URLEncoding, bytes.NewReader([]byte(fields[1]))))
+	if err != nil {
+		return fmt.Errorf("invalid member in cursor string (%s)", err)
 	}
 
 	c.Score = math.Float64frombits(score)

--- a/common/cursor_test.go
+++ b/common/cursor_test.go
@@ -70,6 +70,16 @@ func TestCursorSafety(t *testing.T) {
 	}
 }
 
+func TestIssue37(t *testing.T) {
+	c := Cursor{}
+	if err := c.Parse("4743834931740803072A"); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "", c.Member; want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
 func BenchmarkCursorString(b *testing.B) {
 	var cursor = Cursor{Score: 1.23, Member: "abcdefg"}
 

--- a/farm/repair_strategies_test.go
+++ b/farm/repair_strategies_test.go
@@ -29,8 +29,14 @@ func TestAllRepairs(t *testing.T) {
 		if i == 0 {
 			expected = second
 		}
-		if got := <-clusters[i].SelectOffset([]string{"foo"}, 0, 10); !reflect.DeepEqual(expected, got.KeyScoreMembers[0]) {
+		got := <-clusters[i].SelectOffset([]string{"foo"}, 0, 10)
+		if len(got.KeyScoreMembers) <= 0 {
+			t.Errorf("pre-repair: cluster %d: only got %d responses", i, len(got.KeyScoreMembers))
+			continue
+		}
+		if !reflect.DeepEqual(expected, got.KeyScoreMembers[0]) {
 			t.Errorf("pre-repair: cluster %d: expected %+v, got %+v", i, expected, got.KeyScoreMembers[0])
+			continue
 		}
 	}
 


### PR DESCRIPTION
Fixes #37

/cc @beorn7 